### PR TITLE
Add a sign subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ Options:
 
 Commands:
   archive   Archive files and URLs into a BagIt package.
+  sign      Sign an existing bag.
   validate  Validate a BagIt package.
 ```
 
@@ -161,6 +162,22 @@ Options:
   --timeout FLOAT                 Timeout for collection tasks (default: 5.0)
   --collect-errors [fail|ignore]  How to handle collection task errors
                                   (default: fail)
+  --help                          Show this message and exit.
+```
+
+### sign
+```
+Usage:  [OPTIONS] BAG_PATH
+
+  Sign an existing bag.
+
+Options:
+  -s, --sign <cert_chain>:<key_file>
+                                  Sign using certificate chain and private key
+                                  files (can be repeated)
+  -t, --timestamp <tsa_keyword> | <cert_chain>:<url>
+                                  Timestamp using either a TSA keyword or a
+                                  cert chain path and URL (can be repeated)
   --help                          Show this message and exit.
 ```
 

--- a/uv.lock
+++ b/uv.lock
@@ -1,4 +1,5 @@
 version = 1
+revision = 1
 requires-python = ">=3.11"
 
 [[package]]
@@ -115,7 +116,7 @@ name = "click"
 version = "8.1.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "platform_system == 'Windows'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/96/d3/f04c7bfcf5c1862a2a5b845c6b2b360488cf47af55dfa79c98f6a6bf98b5/click-8.1.7.tar.gz", hash = "sha256:ca9853ad459e787e2192211578cc907e7594e294c7ccc834310722b41b9ca6de", size = 336121 }
 wheels = [
@@ -181,7 +182,7 @@ wheels = [
 
 [package.optional-dependencies]
 toml = [
-    { name = "tomli", marker = "python_full_version == '3.11'" },
+    { name = "tomli", marker = "python_full_version <= '3.11'" },
 ]
 
 [[package]]
@@ -308,7 +309,7 @@ wheels = [
 
 [[package]]
 name = "nabit"
-version = "0.1.1"
+version = "0.1.2"
 source = { editable = "." }
 dependencies = [
     { name = "bagit" },


### PR DESCRIPTION
This commit adds a new `sign` subcommand to sign an existing bag. The thinking here is that the bagit signing functionality could be useful for people who are [creating bags using different tools](https://github.com/edsu/nih-reporter-exporter/blob/a01e9ad26232ea0af7499f7bbf6d542d784142c9/package.sh#L35-L38), and workflows, but would also still like to assert the provenance of the bag with digital signatures.

```shell
$ nabit sign /path/to/my/bag -s cert.pem:key.pem -t digicert                                                                                                             Validating package at bag ...
SUCCESS: bag format is valid
SUCCESS: signature bag/signatures/tagmanifest-sha256.txt.p7s verified
SUCCESS: Timestamp bag/signatures/tagmanifest-sha256.txt.p7s.tsr verified
Package is valid
Package signed at /path/to/my/bag
```

The command first verifies that the given directory is a bag, then adds the signatures, and then validates the bag again.

I did spend some time looking into extracting the signature making functionality into a separate utility. But the logic is complex enough at this stage that I think it makes sense for it to continue to live here in nabit, at least for now? It also seems to be well tested here, and there is not much sense in duplicating that.